### PR TITLE
Chore/remove reflection

### DIFF
--- a/watchconf-api/src/main/java/com/librato/watchconf/adapter/AbstractConfigAdapter.java
+++ b/watchconf-api/src/main/java/com/librato/watchconf/adapter/AbstractConfigAdapter.java
@@ -18,9 +18,11 @@ public abstract class AbstractConfigAdapter<T, V> implements DynamicConfig<T> {
     protected final List<ChangeListener> changeListenerList = new ArrayList();
     protected final AtomicReference<Optional<T>> config = new AtomicReference(Optional.absent());
     protected final Converter<T, V> converter;
+    protected final Class<T> clazz;
 
-    protected AbstractConfigAdapter(Converter<T, V> converter, Optional<ChangeListener<T>> changeListener) {
+    protected AbstractConfigAdapter(Class<T> clazz, Converter<T, V> converter, Optional<ChangeListener<T>> changeListener) {
         Preconditions.checkArgument(converter != null, "converter cannot be null");
+        this.clazz = clazz;
         this.converter = converter;
 
         if (changeListener.isPresent()) {
@@ -32,9 +34,9 @@ public abstract class AbstractConfigAdapter<T, V> implements DynamicConfig<T> {
         return config.get();
     }
 
-    protected void getAndSet(V v, Class<T> t) {
+    protected void getAndSet(V v) {
         try {
-            config.set(Optional.of(converter.toDomain(v, t)));
+            config.set(Optional.of(converter.toDomain(v, clazz)));
         } catch (Exception ex) {
             log.error("unable to parse config", ex);
             notifyListenersOnError(ex);

--- a/watchconf-api/src/main/java/com/librato/watchconf/adapter/file/DynamicConfigFileAdapter.java
+++ b/watchconf-api/src/main/java/com/librato/watchconf/adapter/file/DynamicConfigFileAdapter.java
@@ -20,16 +20,14 @@ public abstract class DynamicConfigFileAdapter<T> extends AbstractConfigAdapter<
     private static final Logger log = LoggerFactory.getLogger(DynamicConfigFileAdapter.class);
     private final File file;
     private final Executor fileWatchExecutor = Executors.newSingleThreadExecutor();
-    private final Class<T> clazz;
 
     public DynamicConfigFileAdapter(Class<T> clazz, String path, Converter<T, byte[]> converter, ChangeListener<T> changeListener) throws IOException, InterruptedException {
-        super(converter, Optional.fromNullable(changeListener));
-        this.clazz = clazz;
+        super(clazz, converter, Optional.fromNullable(changeListener));
         Preconditions.checkArgument(path != null && !path.isEmpty(), "path cannot be null or blank");
         Preconditions.checkArgument(converter != null, "converter cannot be null");
         this.file = new File(stripSlash(path));
 
-        getAndSet(readFile(),clazz);
+        getAndSet(readFile());
 
         WatchService watcher = FileSystems.getDefault().newWatchService();
         Path dir = Paths.get(path.substring(0, path.lastIndexOf("/")));
@@ -109,7 +107,7 @@ public abstract class DynamicConfigFileAdapter<T> extends AbstractConfigAdapter<
                         WatchEvent<Path> ev = (WatchEvent<Path>) event;
                         Path fileName = ev.context();
                         if (this.fileName.equals(fileName.toString())) {
-                            adapter.getAndSet(adapter.readFile(), adapter.clazz);
+                            adapter.getAndSet(adapter.readFile());
                             adapter.notifyListeners();
                         }
                     }

--- a/watchconf-api/src/main/java/com/librato/watchconf/adapter/redis/DynamicConfigRedisAdapter.java
+++ b/watchconf-api/src/main/java/com/librato/watchconf/adapter/redis/DynamicConfigRedisAdapter.java
@@ -24,11 +24,11 @@ public abstract class DynamicConfigRedisAdapter<T> extends AbstractConfigAdapter
     }
 
     public DynamicConfigRedisAdapter(final Class<T> clazz, final String path, final JedisPool jedisPool, Converter<T, byte[]> converter, ChangeListener<T> changeListener) throws Exception {
-        super(converter, Optional.fromNullable(changeListener));
+        super(clazz, converter, Optional.fromNullable(changeListener));
         Preconditions.checkArgument(path != null && !path.isEmpty(), "path cannot be null or blank");
         this.jedisPool = jedisPool;
 
-        getAndSet(jedisPool.getResource().get(path).getBytes(), clazz);
+        getAndSet(jedisPool.getResource().get(path).getBytes());
 
         jedisPool.getResource().configSet("notify-keyspace-events", "AKE");
         redisExecutor.execute(new Runnable() {
@@ -46,7 +46,7 @@ public abstract class DynamicConfigRedisAdapter<T> extends AbstractConfigAdapter
                     public void onPMessage(String s, String s1, String s2) {
                         String value = jedisPool.getResource().get(path);
                         if(value != null) {
-                            getAndSet(value.getBytes(), clazz);
+                            getAndSet(value.getBytes());
                             notifyListeners();
                         }
 

--- a/watchconf-api/src/main/java/com/librato/watchconf/adapter/zookeeper/DynamicConfigZKAdapter.java
+++ b/watchconf-api/src/main/java/com/librato/watchconf/adapter/zookeeper/DynamicConfigZKAdapter.java
@@ -19,7 +19,11 @@ public abstract class DynamicConfigZKAdapter<T> extends AbstractConfigAdapter<T,
     private NodeCacheListener nodeCacheListener;
     private NodeCache nodeCache;
 
-    public DynamicConfigZKAdapter(final String path, final CuratorFramework curatorFramework, Converter<T, byte[]> converter, ChangeListener<T> changeListener) throws Exception {
+    public DynamicConfigZKAdapter(final Class<T> clazz,
+                                  final String path,
+                                  final CuratorFramework curatorFramework,
+                                  Converter<T, byte[]> converter,
+                                  ChangeListener<T> changeListener) throws Exception {
         super(converter, Optional.fromNullable(changeListener));
         Preconditions.checkNotNull(curatorFramework, "CuratorFramework cannot be null");
         Preconditions.checkArgument(curatorFramework.getState() == CuratorFrameworkState.STARTED, "CuratorFramework must be started");
@@ -33,13 +37,13 @@ public abstract class DynamicConfigZKAdapter<T> extends AbstractConfigAdapter<T,
             }
         }
 
-        getAndSet(curatorFramework.getData().forPath(path));
+        getAndSet(curatorFramework.getData().forPath(path), clazz);
 
         this.nodeCache = new NodeCache(curatorFramework, path);
         this.nodeCacheListener = new NodeCacheListener() {
             @Override
             public void nodeChanged() throws Exception {
-                getAndSet(curatorFramework.getData().forPath(path));
+                getAndSet(curatorFramework.getData().forPath(path), clazz);
                 notifyListeners();
             }
         };
@@ -48,7 +52,7 @@ public abstract class DynamicConfigZKAdapter<T> extends AbstractConfigAdapter<T,
         this.nodeCache.start(true);
     }
 
-    public DynamicConfigZKAdapter(String path, CuratorFramework curatorFramework, Converter converter) throws Exception {
-        this(path, curatorFramework, converter, null);
+    public DynamicConfigZKAdapter(Class<T> clazz, String path, CuratorFramework curatorFramework, Converter converter) throws Exception {
+        this(clazz, path, curatorFramework, converter, null);
     }
 }

--- a/watchconf-api/src/main/java/com/librato/watchconf/adapter/zookeeper/DynamicConfigZKAdapter.java
+++ b/watchconf-api/src/main/java/com/librato/watchconf/adapter/zookeeper/DynamicConfigZKAdapter.java
@@ -24,7 +24,7 @@ public abstract class DynamicConfigZKAdapter<T> extends AbstractConfigAdapter<T,
                                   final CuratorFramework curatorFramework,
                                   Converter<T, byte[]> converter,
                                   ChangeListener<T> changeListener) throws Exception {
-        super(converter, Optional.fromNullable(changeListener));
+        super(clazz, converter, Optional.fromNullable(changeListener));
         Preconditions.checkNotNull(curatorFramework, "CuratorFramework cannot be null");
         Preconditions.checkArgument(curatorFramework.getState() == CuratorFrameworkState.STARTED, "CuratorFramework must be started");
         Preconditions.checkArgument(path != null && !path.isEmpty(), "path cannot be null or blank");
@@ -37,13 +37,13 @@ public abstract class DynamicConfigZKAdapter<T> extends AbstractConfigAdapter<T,
             }
         }
 
-        getAndSet(curatorFramework.getData().forPath(path), clazz);
+        getAndSet(curatorFramework.getData().forPath(path));
 
         this.nodeCache = new NodeCache(curatorFramework, path);
         this.nodeCacheListener = new NodeCacheListener() {
             @Override
             public void nodeChanged() throws Exception {
-                getAndSet(curatorFramework.getData().forPath(path), clazz);
+                getAndSet(curatorFramework.getData().forPath(path));
                 notifyListeners();
             }
         };

--- a/watchconf-api/src/test/java/com/librato/watchconf/adapter/redis/DynamicConfigRedisAdapterIT.java
+++ b/watchconf-api/src/test/java/com/librato/watchconf/adapter/redis/DynamicConfigRedisAdapterIT.java
@@ -26,7 +26,7 @@ public class DynamicConfigRedisAdapterIT {
     public static class ExampleConfigAdapter extends DynamicConfigRedisAdapter<ExampleConfig> {
 
         public ExampleConfigAdapter(JedisPool jedis, ChangeListener<ExampleConfig> changeListener) throws Exception {
-            super("config", jedis, new JsonConverter<ExampleConfig>(), changeListener);
+            super(ExampleConfig.class, "config", jedis, new JsonConverter<ExampleConfig>(), changeListener);
         }
     }
 

--- a/watchconf-api/src/test/java/com/librato/watchconf/adapter/zookeeper/DynamicConfigZKAdapterIT.java
+++ b/watchconf-api/src/test/java/com/librato/watchconf/adapter/zookeeper/DynamicConfigZKAdapterIT.java
@@ -27,11 +27,11 @@ public class DynamicConfigZKAdapterIT {
     private class ExampleConfigAdapter extends DynamicConfigZKAdapter<ExampleConfig> {
 
         public ExampleConfigAdapter(CuratorFramework curatorFramework) throws Exception {
-            super("/watchconf/test/config", curatorFramework, new JsonConverter<ExampleConfig>());
+            super(ExampleConfig.class, "/watchconf/test/config", curatorFramework, new JsonConverter<ExampleConfig>());
         }
 
         public ExampleConfigAdapter(CuratorFramework curatorFramework, ChangeListener<ExampleConfig> changeListener) throws Exception {
-            super("/watchconf/test/config", curatorFramework, new JsonConverter<ExampleConfig>(), changeListener);
+            super(ExampleConfig.class,"/watchconf/test/config", curatorFramework, new JsonConverter<ExampleConfig>(), changeListener);
         }
     }
 

--- a/watchconf-api/src/test/java/com/librato/watchconf/adapter/zookeeper/DynamicConfigZKAdapterTest.java
+++ b/watchconf-api/src/test/java/com/librato/watchconf/adapter/zookeeper/DynamicConfigZKAdapterTest.java
@@ -25,7 +25,7 @@ public class DynamicConfigZKAdapterTest {
     private class ExampleConfigAdapter extends DynamicConfigZKAdapter<ExampleConfig> {
 
         public ExampleConfigAdapter(CuratorFramework curatorFramework) throws Exception {
-            super("/test/config", curatorFramework, new JsonConverter<ExampleConfig>());
+            super(ExampleConfig.class, "/test/config", curatorFramework, new JsonConverter<ExampleConfig>());
         }
     }
 

--- a/watchconf-api/src/test/java/com/librato/watconf/adapter/file/DynamicConfigFileAdapterTest.java
+++ b/watchconf-api/src/test/java/com/librato/watconf/adapter/file/DynamicConfigFileAdapterTest.java
@@ -21,11 +21,11 @@ public class DynamicConfigFileAdapterTest {
 
     public static class ExampleConfigAdapter extends DynamicConfigFileAdapter<ExampleConfig> {
         public ExampleConfigAdapter(String path, Converter<ExampleConfig, byte[]> converter) throws IOException, InterruptedException {
-            super(path, converter);
+            super(ExampleConfig.class, path, converter);
         }
 
         public ExampleConfigAdapter(String path, Converter<ExampleConfig, byte[]> converter, ChangeListener<ExampleConfig> changeListener) throws IOException, InterruptedException {
-            super(path, converter, changeListener);
+            super(ExampleConfig.class, path, converter, changeListener);
         }
     }
 


### PR DESCRIPTION
This PR removes the getClassForType method that used reflection to derive the required class object and now just requires that the user passes as part of the constructor. cc: @collinvandyck @lucky 