### PR TITLE
Remove sync calls in favor of reading from NodeCache.

### DIFF
--- a/watchconf-api/src/main/java/com/librato/watchconf/DynamicConfig.java
+++ b/watchconf-api/src/main/java/com/librato/watchconf/DynamicConfig.java
@@ -44,6 +44,11 @@ public interface DynamicConfig<T> {
     void removeListener(ChangeListener changeListener);
 
     /**
+     * Start the adapter
+     */
+    void start() throws Exception;
+
+    /**
      * Shutdown a dynamic configuration
      */
     void shutdown() throws Exception;

--- a/watchconf-api/src/main/java/com/librato/watchconf/adapter/AbstractConfigAdapter.java
+++ b/watchconf-api/src/main/java/com/librato/watchconf/adapter/AbstractConfigAdapter.java
@@ -54,9 +54,9 @@ public abstract class AbstractConfigAdapter<T, V> implements DynamicConfig<T> {
         changeListenerList.remove(changeListener);
     }
 
-    protected void notifyListeners() {
+    protected void notifyListeners(Optional<T> t) {
         for (ChangeListener changeListener : changeListenerList) {
-            changeListener.onChange(config.get());
+            changeListener.onChange(t);
         }
     }
 

--- a/watchconf-api/src/main/java/com/librato/watchconf/adapter/AbstractConfigAdapter.java
+++ b/watchconf-api/src/main/java/com/librato/watchconf/adapter/AbstractConfigAdapter.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 import java.lang.reflect.ParameterizedType;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 public abstract class AbstractConfigAdapter<T, V> implements DynamicConfig<T> {
@@ -19,6 +20,7 @@ public abstract class AbstractConfigAdapter<T, V> implements DynamicConfig<T> {
     protected final AtomicReference<Optional<T>> config = new AtomicReference(Optional.absent());
     protected final Converter<T, V> converter;
     protected final Class<T> clazz;
+    protected final AtomicBoolean started = new AtomicBoolean(false);
 
     protected AbstractConfigAdapter(Class<T> clazz, Converter<T, V> converter, Optional<ChangeListener<T>> changeListener) {
         Preconditions.checkArgument(converter != null, "converter cannot be null");
@@ -31,6 +33,7 @@ public abstract class AbstractConfigAdapter<T, V> implements DynamicConfig<T> {
     }
 
     public Optional<T> get() throws Exception {
+        Preconditions.checkArgument(started.get(), "Adapter must be started before calling get");
         return config.get();
     }
 

--- a/watchconf-api/src/main/java/com/librato/watchconf/adapter/file/DynamicConfigFileAdapter.java
+++ b/watchconf-api/src/main/java/com/librato/watchconf/adapter/file/DynamicConfigFileAdapter.java
@@ -113,7 +113,12 @@ public abstract class DynamicConfigFileAdapter<T> extends AbstractConfigAdapter<
                         Path fileName = ev.context();
                         if (this.fileName.equals(fileName.toString())) {
                             adapter.getAndSet(adapter.readFile());
-                            adapter.notifyListeners();
+                            try {
+                                adapter.notifyListeners(adapter.get());
+                            } catch (Exception ex) {
+                                log.error("unable to notify listeners", ex);
+                                adapter.notifyListenersOnError(ex);
+                            }
                         }
                     }
 

--- a/watchconf-api/src/main/java/com/librato/watchconf/adapter/zookeeper/DynamicConfigZKAdapter.java
+++ b/watchconf-api/src/main/java/com/librato/watchconf/adapter/zookeeper/DynamicConfigZKAdapter.java
@@ -49,7 +49,7 @@ public abstract class DynamicConfigZKAdapter<T> extends AbstractConfigAdapter<T,
         this.nodeCacheListener = new NodeCacheListener() {
             @Override
             public void nodeChanged() throws Exception {
-                notifyListeners();
+                notifyListeners(get());
             }
         };
 

--- a/watchconf-api/src/test/java/com/librato/watchconf/adapter/redis/DynamicConfigRedisAdapterIT.java
+++ b/watchconf-api/src/test/java/com/librato/watchconf/adapter/redis/DynamicConfigRedisAdapterIT.java
@@ -43,6 +43,7 @@ public class DynamicConfigRedisAdapterIT {
         ec.name = "ray";
         pool.getResource().set("config", objectMapper.writeValueAsString(ec));
         ExampleConfigAdapter exampleConfigAdapter = new ExampleConfigAdapter(pool, null);
+        exampleConfigAdapter.start();
         Optional<ExampleConfig> exampleConfig = exampleConfigAdapter.get();
         assertTrue(exampleConfig.isPresent());
         assertEquals("ray", exampleConfig.get().name);
@@ -73,7 +74,7 @@ public class DynamicConfigRedisAdapterIT {
             public void onError(Exception ex) {
 
             }
-        });
+        }).start();
 
         Executors.newSingleThreadScheduledExecutor().schedule(new Runnable() {
             @Override

--- a/watchconf-api/src/test/java/com/librato/watchconf/adapter/zookeeper/DynamicConfigZKAdapterIT.java
+++ b/watchconf-api/src/test/java/com/librato/watchconf/adapter/zookeeper/DynamicConfigZKAdapterIT.java
@@ -31,7 +31,7 @@ public class DynamicConfigZKAdapterIT {
         }
 
         public ExampleConfigAdapter(CuratorFramework curatorFramework, ChangeListener<ExampleConfig> changeListener) throws Exception {
-            super(ExampleConfig.class,"/watchconf/test/config", curatorFramework, new JsonConverter<ExampleConfig>(), changeListener);
+            super(ExampleConfig.class, "/watchconf/test/config", curatorFramework, new JsonConverter<ExampleConfig>(), changeListener);
         }
     }
 
@@ -77,6 +77,7 @@ public class DynamicConfigZKAdapterIT {
         framework.create().creatingParentsIfNeeded().forPath("/watchconf/test/config", objectMapper.writeValueAsBytes(exampleConfig));
 
         ExampleConfigAdapter exampleConfigAdapter = new ExampleConfigAdapter(framework);
+        exampleConfigAdapter.start();
         Optional<ExampleConfig> fetchedConfig = exampleConfigAdapter.get();
         assertTrue(fetchedConfig.isPresent());
         assertEquals("test123", fetchedConfig.get().name);
@@ -108,6 +109,8 @@ public class DynamicConfigZKAdapterIT {
 
             }
         });
+
+        exampleConfigAdapter.start();
 
         Executors.newSingleThreadScheduledExecutor().schedule(new Callable<Void>() {
             @Override

--- a/watchconf-api/src/test/java/com/librato/watchconf/adapter/zookeeper/DynamicConfigZKAdapterTest.java
+++ b/watchconf-api/src/test/java/com/librato/watchconf/adapter/zookeeper/DynamicConfigZKAdapterTest.java
@@ -87,6 +87,7 @@ public class DynamicConfigZKAdapterTest {
         when(existsBuilder.usingWatcher(any(CuratorWatcher.class))).thenReturn(existsBuilder);
         when(existsBuilder.inBackground(any(BackgroundCallback.class))).thenReturn(existsBuilder);
         ExampleConfigAdapter exampleConfigAdapter = new ExampleConfigAdapter(curatorFramework);
+        exampleConfigAdapter.start();
         assertNotNull(exampleConfigAdapter);
         assertTrue(exampleConfigAdapter.get().isPresent());
         assertEquals(exampleConfigAdapter.get().get().name, "ray");

--- a/watchconf-api/src/test/java/com/librato/watconf/adapter/file/DynamicConfigFileAdapterTest.java
+++ b/watchconf-api/src/test/java/com/librato/watconf/adapter/file/DynamicConfigFileAdapterTest.java
@@ -33,6 +33,7 @@ public class DynamicConfigFileAdapterTest {
     public void testReadConfig() throws Exception {
         URL url = this.getClass().getResource("/example_config.yml");
         ExampleConfigAdapter exampleConfigAdapter = new ExampleConfigAdapter(url.getFile(), new YAMLConverter<ExampleConfig>());
+        exampleConfigAdapter.start();
         Optional<ExampleConfig> exampleConfig = exampleConfigAdapter.get();
         assertTrue(exampleConfig.isPresent());
         assertEquals(1, exampleConfig.get().id);
@@ -57,6 +58,7 @@ public class DynamicConfigFileAdapterTest {
             }
         });
 
+        exampleConfigAdapter.start();
         ExampleConfig exampleConfig = exampleConfigAdapter.get().get();
         exampleConfig.id = 100;
         exampleConfig.name = "ray";


### PR DESCRIPTION
 Call getAndSet on adapter after NodeCache has initialized. @mheffner I am still a little concerned that there is a possibility that the NodeCache could become stale if a write occurs while in the call to .start(true). That method initializes the Cache and then sets a watch. If an infrequent write were to occur between those 2 calls it may be possible for the cache to remain stale, as a stopgap we could expose a rebuild() API that calls nodeCache.rebuild(). This could then be called on some frequency from amnis to ensure if we ever hit the situation we recover.